### PR TITLE
Rotate ArrowUp icons instead of using now-defunct ArrowDown

### DIFF
--- a/views/gpio_usb_uart.c
+++ b/views/gpio_usb_uart.c
@@ -80,9 +80,9 @@ static void gpio_usb_uart_draw_callback(Canvas* canvas, void* _model) {
         canvas_draw_icon(canvas, 48, 14, &I_ArrowUpEmpty_14x15);
 
     if(model->rx_active)
-        canvas_draw_icon(canvas, 48, 34, &I_ArrowDownFilled_14x15);
+        canvas_draw_icon_ex(canvas, 48, 34, &I_ArrowUpFilled_14x15, IconRotation180);
     else
-        canvas_draw_icon(canvas, 48, 34, &I_ArrowDownEmpty_14x15);
+        canvas_draw_icon_ex(canvas, 48, 34, &I_ArrowUpEmpty_14x15, IconRotation180);
 }
 
 static bool gpio_usb_uart_input_callback(InputEvent* event, void* context) {


### PR DESCRIPTION
`I_ArrowDownFilled_14x15` and `I_ArrowDownEmpty_14x15` no longer exist in recent firmware updates, but `canvas_draw_icon_ex` function lets us rotate icons.